### PR TITLE
Add Android job aggregator skeleton

### DIFF
--- a/JobAggregatorApp/app/build.gradle
+++ b/JobAggregatorApp/app/build.gradle
@@ -1,0 +1,51 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.jobaggregator'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.jobaggregator'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+    kotlinOptions {
+        jvmTarget = '21'
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.11'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.9.0'
+
+    implementation platform('androidx.compose:compose-bom:2024.02.00')
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+
+    implementation 'com.google.android.gms:play-services-ads:22.6.0'
+}

--- a/JobAggregatorApp/app/proguard-rules.pro
+++ b/JobAggregatorApp/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/JobAggregatorApp/app/src/main/AndroidManifest.xml
+++ b/JobAggregatorApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.jobaggregator">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.JobAggregator">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/JobAggregatorApp/app/src/main/java/com/example/jobaggregator/MainActivity.kt
+++ b/JobAggregatorApp/app/src/main/java/com/example/jobaggregator/MainActivity.kt
@@ -1,0 +1,76 @@
+package com.example.jobaggregator
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdRequest
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.android.gms.ads.MobileAds
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        MobileAds.initialize(this)
+
+        setContent {
+            JobAggregatorTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    JobScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun JobScreen(vm: JobViewModel = viewModel()) {
+    val jobs by vm.jobs.collectAsState()
+    Column {
+        AndroidView(factory = { context ->
+            AdView(context).apply {
+                adSize = AdSize.BANNER
+                adUnitId = "ca-app-pub-xxxxxxxxxxxxxxxx/xxxxxxxxxx" // TODO replace
+                loadAd(AdRequest.Builder().build())
+            }
+        })
+        LazyColumn {
+            items(jobs.size) { index ->
+                Text(text = jobs[index].title)
+            }
+        }
+    }
+}
+
+data class JobPosting(val title: String, val approved: Boolean)
+
+class JobViewModel : ViewModel() {
+    private val _jobs = MutableStateFlow<List<JobPosting>>(emptyList())
+    val jobs: StateFlow<List<JobPosting>> = _jobs
+
+    init {
+        fetchJobs()
+    }
+
+    private fun fetchJobs() {
+        // TODO: replace with real implementation to fetch from sources
+        _jobs.value = listOf(
+            JobPosting("Sample Job 1", approved = true),
+            JobPosting("مثال وظيفة", approved = true)
+        )
+    }
+}

--- a/JobAggregatorApp/app/src/main/java/com/example/jobaggregator/ui/theme/Theme.kt
+++ b/JobAggregatorApp/app/src/main/java/com/example/jobaggregator/ui/theme/Theme.kt
@@ -1,0 +1,32 @@
+package com.example.jobaggregator.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF6200EE),
+    secondary = Color(0xFF03DAC5)
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFBB86FC),
+    secondary = Color(0xFF03DAC5)
+)
+
+@Composable
+fun JobAggregatorTheme(content: @Composable () -> Unit) {
+    val colors = if (androidx.compose.foundation.isSystemInDarkTheme()) {
+        DarkColors
+    } else {
+        LightColors
+    }
+
+    MaterialTheme(
+        colorScheme = colors,
+        content = content
+    )
+}

--- a/JobAggregatorApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/JobAggregatorApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#6200EE"
+        android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/JobAggregatorApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/JobAggregatorApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#6200EE"
+        android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/JobAggregatorApp/app/src/main/res/values-ar/strings.xml
+++ b/JobAggregatorApp/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">تجميع الوظائف السعودية</string>
+</resources>

--- a/JobAggregatorApp/app/src/main/res/values-night/themes.xml
+++ b/JobAggregatorApp/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.JobAggregator" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/JobAggregatorApp/app/src/main/res/values/colors.xml
+++ b/JobAggregatorApp/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/JobAggregatorApp/app/src/main/res/values/strings.xml
+++ b/JobAggregatorApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Job Aggregator SA</string>
+</resources>

--- a/JobAggregatorApp/app/src/main/res/values/themes.xml
+++ b/JobAggregatorApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.JobAggregator" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="23">@bool/is_light_theme</item>
+    </style>
+</resources>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# adearnpro-release
+# Job Aggregator SA
+
+This repository contains a minimal Android application written in Kotlin using Jetpack Compose. The application demonstrates how to aggregate job postings for Saudi Arabia with support for Arabic and English locales, dark mode and basic Google AdMob integration.
+
+## Modules
+- **app** – Android application module written in Kotlin/Jetpack Compose.
+
+## Features
+- Multilingual support (English/Arabic)
+- Dark/light theme
+- Placeholder job fetching with approval logic
+- Banner advertisement using Google Mobile Ads SDK
+
+## Building
+This project uses the standard Gradle build system. Make sure the Android SDK is installed and run:
+
+```bash
+./gradlew assembleDebug
+```
+
+## Note
+The job-fetching implementation is only a stub. Replace `fetchJobs()` inside `JobViewModel` with real logic to collect jobs from Saudi government and company sources and implement approval flow as required.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'com.android.application' version '8.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "JobAggregatorApp"
+include(":app")


### PR DESCRIPTION
## Summary
- replace placeholder README with project info
- add gradle build files and Android app module
- implement minimal Jetpack Compose UI with Arabic/English resources
- integrate AdMob banner placeholder and dark theme support

## Testing
- `gradle tasks --all` *(fails: plugin not found because of offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68874f16cd388326b041c57b19adb55b